### PR TITLE
fix multiple resove(stream)

### DIFF
--- a/src/JsonStream.php
+++ b/src/JsonStream.php
@@ -309,6 +309,10 @@ final class JsonStream extends EventEmitter implements ReadableStreamInterface
 
     private function wrapValue(mixed $value): mixed
     {
+        if ($value instanceof PromiseInterface) {
+            return $value->then(fn ($result) => $this->wrapValue($result));
+        }
+        
         if ($value instanceof JsonStream) {
             return new BufferingJsonStream($value);
         }


### PR DESCRIPTION
```
use React\Stream\ThroughStream;
use WyriHaximus\React\Stream\Json\JsonStream;
use function React\Promise\resolve;
use React\EventLoop\Factory;
use React\EventLoop\TimerInterface;

$loop = Factory::create();
$anotherStream = new ThroughStream();
$anotherStream1 = new ThroughStream();

$jsonStream = new JsonStream();
$jsonStream->on('data', function($buffer){
    echo $buffer;
});

$jsonStream->end([
    'first',
    resolve($anotherStream),
    resolve($anotherStream1),
    resolve('third'),
]);

$i = 0;
$loop->addPeriodicTimer(1, function (TimerInterface $timer) use ($anotherStream, &$i, $loop): void {
    $i++;
    $anotherStream->write((string)$i);
    if ($i >10) {
        $anotherStream->end();
        $loop->cancelTimer($timer);
    }
});

$j = 0;
$loop->addPeriodicTimer(1, function (TimerInterface $timer) use ($anotherStream1, &$j, $loop): void {
    $j++;
    $anotherStream1->write((string)($j));
    if ($j >10 ) {
        $anotherStream1->end();
        $loop->cancelTimer($timer);
    }
});


$loop->run();
```

before ouput

```
["first","1234567891011","11","third"]
```

fixed after output
```
["first","1234567891011","1234567891011","third"]
```